### PR TITLE
Exception for blank nutrition cells, clea up print statements

### DIFF
--- a/app/core/ingredients_db.py
+++ b/app/core/ingredients_db.py
@@ -325,7 +325,12 @@ def parse_ingredient(row) -> ScopedIngredient:
     variant_rarity = map_rarity(row["variant rarity"])
     variant_id = row["unique_id"][3:4]
 
-    nutrition = parse_nutrition(row)
+    try:
+        nutrition = parse_nutrition(row)
+    except Exception as e:
+        r = row["unique_id"]
+        print(f"Parse nutrition error for ingredient:  {r} -- Using default")
+        nutrition = default_nutrition()
 
     ingredient = Ingredient(
         unique_id=row["unique_id"],
@@ -609,44 +614,48 @@ def parse_nutrition(row) -> NutritionMetadata:
             manganese=row["manganese"],
         )
     else:
-        data = NutritionMetadata(
-            serving_size=0,
-            mass=0,
-            calories=0,
-            vitamin_c=0,
-            magnesium=0,
-            vitamin_b5=0,
-            vitamin_d=0,
-            vitamin_b7=0,
-            height=0,
-            moisture=0,
-            potassium=0,
-            cholesterol=0,
-            vitamin_a=0,
-            dietary_fiber=0,
-            vitamin_b6=0,
-            sugar=0,
-            protein=0,
-            iron=0,
-            complex_carb=0,
-            selenium=0,
-            vitamin_k=0,
-            vitamin_b12=0,
-            calories_from_fat=0,
-            vitamin_e=0,
-            zinc=0,
-            saturated_fat=0,
-            iodine=0,
-            trans_fat=0,
-            sodium=0,
-            monosaturated_fat=0,
-            calcium=0,
-            riboflavin=0,
-            thiamin=0,
-            folate=0,
-            added_sugar=0,
-            chromium=0,
-            manganese=0,
-        )
+        return default_nutrition()
 
     return data
+
+
+def default_nutrition() -> NutritionMetadata:
+    return NutritionMetadata(
+        serving_size=0,
+        mass=0,
+        calories=0,
+        vitamin_c=0,
+        magnesium=0,
+        vitamin_b5=0,
+        vitamin_d=0,
+        vitamin_b7=0,
+        height=0,
+        moisture=0,
+        potassium=0,
+        cholesterol=0,
+        vitamin_a=0,
+        dietary_fiber=0,
+        vitamin_b6=0,
+        sugar=0,
+        protein=0,
+        iron=0,
+        complex_carb=0,
+        selenium=0,
+        vitamin_k=0,
+        vitamin_b12=0,
+        calories_from_fat=0,
+        vitamin_e=0,
+        zinc=0,
+        saturated_fat=0,
+        iodine=0,
+        trans_fat=0,
+        sodium=0,
+        monosaturated_fat=0,
+        calcium=0,
+        riboflavin=0,
+        thiamin=0,
+        folate=0,
+        added_sugar=0,
+        chromium=0,
+        manganese=0,
+    )

--- a/app/core/prep_line.py
+++ b/app/core/prep_line.py
@@ -233,13 +233,14 @@ def select_prep(
 
     if scope.scope.scatter_types[0] == ScatterType.none:
         # This a a base layer or lastchance, so there should only be one selected variant
-        ingredient = selected_variants[0]
         scatter_type = ScatterType.none
-        scale = ingredient.scope.particle_scale[0]
-        rotation = round(select_value(seed, nonce, ingredient.scope.rotation))
-        translation = (0.0, 0.0)
-        if ingredient.ingredient.classification == Classification.lastchance:
-            translation = (3072 / 2, 3072 / 2)
+        if len(selected_variants) >= 1:
+            ingredient = selected_variants[0]
+            scale = ingredient.scope.particle_scale[0]
+            rotation = round(select_value(seed, nonce, ingredient.scope.rotation))
+            translation = (0.0, 0.0)
+            if ingredient.ingredient.classification == Classification.lastchance:
+                translation = (3072 / 2, 3072 / 2)
 
         instances = [
             MadeIngredientPrep(

--- a/app/core/repository.py
+++ b/app/core/repository.py
@@ -53,7 +53,7 @@ def get_oven_params() -> OvenToppingParams:
             result = storage.get({"document_id": "oven_params"})
             # If we can't get OvenToppingParams just return default - one might not be stored locally?
             if not result:
-                print("Returning a default OvenToppingParams object")
+                #print("Returning a default OvenToppingParams object")
                 return OvenToppingParams()
             else:
                 return OvenToppingParams(**result)

--- a/app/core/storage.py
+++ b/app/core/storage.py
@@ -104,7 +104,7 @@ class LocalStorage(IStorage):
         """An inefficient search through all files in the directory."""
         # query_string = json.dumps(dict(filter))
         query_string = re.sub(r"\{|\}", r"", json.dumps(dict(filter)))
-        print(query_string)
+        #print(query_string)
 
         search_files = [
             file


### PR DESCRIPTION
Exception for blank nutrition cells. Will return a default nutritionalMetadata for any rows that cannot be parsed

Removed print statements in Storage and Repository for OvenToppingParams

Added a test to prevent indeed error when assigning variants