### PR TITLE
put back return statement

### DIFF
--- a/app/core/scatter.py
+++ b/app/core/scatter.py
@@ -539,3 +539,4 @@ class RandomScatter(Scatter):
         x = random_radius * cos(random_angle)
         y = random_radius * sin(random_angle)
 
+        return (x,y)


### PR DESCRIPTION
Somehow the return statement was dropped from the random point function in RandomScatter.

Putting it back