### PR TITLE
Fixing variants not showing up by parsing filenames from instances

### DIFF
--- a/app/core/natron/box.py
+++ b/app/core/natron/box.py
@@ -6,6 +6,17 @@ from natron_base import NatronBase
 class Box(NatronBase):
     """base class override"""
 
+    def __init__(self, app, env_var):
+        self.natron = app
+        self._load_json_data(env_var)
+
+        for item in self.instances:
+            index = self.instances.index(item)
+            image_uri = item["image_uri"]
+            self._load_image(image_uri, index)
+
+        self._setBake()
+
 
 instance = Box(app, "BOX_DATA_PATH")
 instance.render()

--- a/app/core/natron/cheese.py
+++ b/app/core/natron/cheese.py
@@ -6,6 +6,17 @@ from natron_base import NatronBase
 class Cheese(NatronBase):
     """base class override"""
 
+    def __init__(self, app, env_var):
+        self.natron = app
+        self._load_json_data(env_var)
+
+        for item in self.instances:
+            index = self.instances.index(item)
+            image_uri = item["image_uri"]
+            self._load_image(image_uri, index)
+
+        self._setBake()
+
 
 instance = Cheese(app, "CHEESE_DATA_PATH")
 instance.render()

--- a/app/core/natron/crust.py
+++ b/app/core/natron/crust.py
@@ -6,6 +6,17 @@ from natron_base import NatronBase
 class Crust(NatronBase):
     """base class override"""
 
+    def __init__(self, app, env_var):
+        self.natron = app
+        self._load_json_data(env_var)
+
+        for item in self.instances:
+            index = self.instances.index(item)
+            image_uri = item["image_uri"]
+            self._load_image(image_uri, index)
+
+        self._setBake()
+
 
 instance = Crust(app, "CRUST_DATA_PATH")
 instance.render()

--- a/app/core/natron/paper.py
+++ b/app/core/natron/paper.py
@@ -6,6 +6,17 @@ from natron_base import NatronBase
 class Paper(NatronBase):
     """base class override"""
 
+    def __init__(self, app, env_var):
+        self.natron = app
+        self._load_json_data(env_var)
+
+        for item in self.instances:
+            index = self.instances.index(item)
+            image_uri = item["image_uri"]
+            self._load_image(image_uri, index)
+
+        self._setBake()
+
 
 instance = Paper(app, "PAPER_DATA_PATH")
 instance.render()

--- a/app/core/natron/sauce.py
+++ b/app/core/natron/sauce.py
@@ -6,6 +6,17 @@ from natron_base import NatronBase
 class Sauce(NatronBase):
     """base class override"""
 
+    def __init__(self, app, env_var):
+        self.natron = app
+        self._load_json_data(env_var)
+
+        for item in self.instances:
+            index = self.instances.index(item)
+            image_uri = item["image_uri"]
+            self._load_image(image_uri, index)
+
+        self._setBake()
+
 
 instance = Sauce(app, "SAUCE_DATA_PATH")
 instance.render()

--- a/app/core/prep_line.py
+++ b/app/core/prep_line.py
@@ -171,8 +171,8 @@ def select_ingredients(
                     chosen_ids.append(ingredient_id)
 
                     print(
-                        "We chose %s for the %s"
-                        % (reduced_dict[identifier].ingredient.name, key)
+                        "We chose %s(%s) for the %s"
+                        % (reduced_dict[identifier].ingredient.name, ingredient_id, key)
                     )
             # Re-order the layer dict, sorted by ingredient ID - lower on the bottom
             # rememeber: reduced_dict contains key/value pairs in the form of "topping0":MadeIngredient
@@ -223,7 +223,7 @@ def select_prep(
     seed: int, nonce: Counter, scope: ScopedIngredient, oven_params: OvenToppingParams
 ) -> MadeIngredient:
     """select the scalar values for the ingredient"""
-
+    print("SELECT PREP NOW")
     # now create a list of instances made of all the variants for a given ingredient
     id = scope.ingredient.ingredient_id
     # A list of ingredients filtered as variants available for a topping - with rarity
@@ -242,7 +242,7 @@ def select_prep(
             ingredient = selected_variants[0]
             scale = ingredient.scope.particle_scale[0]
             rotation = round(select_value(seed, nonce, ingredient.scope.rotation))
-            
+
             if ingredient.ingredient.classification == Classification.lastchance:
                 translation = (3072 / 2, 3072 / 2)
 

--- a/app/core/rarity.py
+++ b/app/core/rarity.py
@@ -95,7 +95,8 @@ def ingredient_with_rarity(
     #     f = freq[i]
     #     ing = rarity_as_string(ingredient.ingredient.ingredient_rarity)
     #     var = rarity_as_string(ingredient.ingredient.variant_rarity)
-    #     print(f"{ingredient.ingredient.unique_id} -- {ing}---{f}    {var}")
+    #     na = ingredient.ingredient.name
+    #     print(f"{ingredient.ingredient.unique_id} -- {na} -- {ing}---{f}    {var}")
 
     index = random_weighted_index(random_seed, nonce, 1, freq)
 

--- a/app/core/test/simple_render.py
+++ b/app/core/test/simple_render.py
@@ -41,7 +41,11 @@ class SimpleRenderer:
         base = Image.new(mode="RGB", size=(3072, 3072), color=(125, 125, 125))
         # iterate through each the base ingredients and render
         for (_, ingredient) in order.base_ingredients.items():
-            filename = ingredient.ingredient.image_uris["filename"]
+            instance = ingredient.instances[0]
+            filename = instance.image_uri
+            if not filename:
+                filename = ingredient.ingredient.image_uris["filename"]
+
             file = os.path.join(images_db, filename)
             print("pasting: " + filename)
             try:
@@ -83,7 +87,6 @@ class SimpleRenderer:
                         except Exception as e:
                             print("skipping image... can't find " + filename)
 
-                
                 # Cale image based on 1024 pixel dimension
                 n = int(1024 * prep.scale)
                 # last minute defense against negative scale values


### PR DESCRIPTION
Variants for base layers were not showing up. This was due to using the image_uri from the ingredient layer, rather than the image_uri in the instance object supplied with the layer.

The fix was to override the _ini_ method in the layer py files, setting the image_uri from the instance list. Same process used for toppings, now also used in base layers