### PR TITLE
adding a feature to check image scale and adjust if needed

### DIFF
--- a/app/core/custom_ko.py
+++ b/app/core/custom_ko.py
@@ -32,6 +32,7 @@ from app.core.random_num import (
 )
 from app.core.scatter import Grid, RandomScatter, TreeRing
 from app.core.utils import clamp, to_hex, from_hex
+from app.core.repository import get_oven_params
 
 
 def get_kitchen_order(unique_id: str):
@@ -213,16 +214,18 @@ def make_prep(
 
     ingredient_list = [scope] * options[0]
 
+    oven_params = get_oven_params()
+
     scatter_type = ScatterType.random
     if options[1] == RandomScatter:
         scatter_type = ScatterType.random
-        instances = RandomScatter(seed, nonce).evaluate(ingredient_list)
+        instances = RandomScatter(seed, nonce, oven_params).evaluate(ingredient_list)
     if options[1] == Grid:
         scatter_type = ScatterType.grid
-        instances = Grid(seed, nonce).evaluate(ingredient_list)
+        instances = Grid(seed, nonce, oven_params).evaluate(ingredient_list)
     if options[1] == TreeRing:
         scatter_type = ScatterType.treering
-        instances = TreeRing(seed, nonce).evaluate(ingredient_list)
+        instances = TreeRing(seed, nonce, oven_params).evaluate(ingredient_list)
 
     return MadeIngredient(
         ingredient=scope.ingredient,


### PR DESCRIPTION
Adding a feature to check the size of images in dining_setup

If images are not 1024 on one side, they are scaled down and saved

Images in the DB should be 1024x1024, but sometimes they are not. This is a defense against those offenders.

This could be changed by introducing a new scaling also, but at this point that seems to risky to implement and test